### PR TITLE
DW initial revisions

### DIFF
--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -836,8 +836,8 @@ class InterpolationMixin:
         method : dict | str | None
             Method to use for each channel type.
 
-            - ``"meg"`` channels support ``"MNE"`` (default) and ``"nan"
-            - ``"eeg"`` channels support ``"spline"`` (default), ``"MNE"`` and ``"nan"
+            - ``"meg"`` channels support ``"MNE"`` (default) and ``"nan"``
+            - ``"eeg"`` channels support ``"spline"`` (default), ``"MNE"`` and ``"nan"``
             - ``"fnirs"`` channels support ``"nearest"`` (default) and ``"nan"``
 
             None is an alias for::

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -707,6 +707,9 @@ class BaseEpochs(
             List of arrays with indices of bad epochs per channel.
         verbose : bool, str, int, or None
         """
+        if not self.preload:
+            raise ValueError("Data must be preloaded.")
+
         if len(bad_epochs_indices) != self.get_data().shape[1]:
             raise RuntimeError(
                 "The length of the list of bad epochs indices "
@@ -1209,7 +1212,7 @@ class BaseEpochs(
                 n_events += 1
 
             if n_events > 0:
-                data = np.nanmean(data)
+                data /= n_events
             else:
                 data.fill(np.nan)
 

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -5204,3 +5204,19 @@ def test_empty_error(method, epochs_empty):
         pytest.importorskip("pandas")
     with pytest.raises(RuntimeError, match="is empty."):
         getattr(epochs_empty.copy(), method[0])(**method[1])
+
+
+def test_set_bad_epochs_to_nan():
+    """Test channel specific epoch rejection."""
+    # preload=False
+    raw, ev, _ = _get_data(preload=False)
+    ep = Epochs(raw, ev, tmin=0, tmax=0.1, baseline=(0, 0))
+    bads = [[]] * ep.info["nchan"]
+    bads[0] = [1]
+    with pytest.raises(ValueError, match="must be preloaded"):
+        ep.set_bad_epochs_to_NaN(bads)
+
+    # preload=True
+    ep.load_data()
+    ep.set_bad_epochs_to_NaN(bads)
+    _ = ep.average()

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -901,12 +901,12 @@ def _check_combine(mode, valid=("mean", "median", "std"), axis=0):
     if mode == "mean":
 
         def fun(data):
-            return np.mean(data, axis=axis)
+            return np.nanmean(data, axis=axis)
 
     elif mode == "std":
 
         def fun(data):
-            return np.std(data, axis=axis)
+            return np.nanstd(data, axis=axis)
 
     elif mode == "median" or mode == np.median:
 


### PR DESCRIPTION
hi @CarinaFo 

here my initial revisions that make it work (i think).
main changes:
- the `nanmean` function had to be swapped somewhere else, 
- applying your method is now only allowed if data are preloaded (which makes things easier and i think is valid).
- i added an initial test

it's just quick and dirty fixes.. e.g., the test could be much better.
also not sure if we should really change `mean` to `nanmean` in the global util function, or whether it makes more sense to allow `nanmean` as an additional separate option and call it based on a (to be implemented) flag, that epochs were rejected (`_check_combine` is only used in `epochs.py` and `tfr.py`, probably for a similar case, but who knows..).






 
